### PR TITLE
Revert "egregious code golf"

### DIFF
--- a/stargazer.rb
+++ b/stargazer.rb
@@ -1,5 +1,11 @@
 `touch stargazer.log`
 
-while (puts ip = ([proc { Random.rand(0..255) }]*4).map(&:call).join('.')) || ip
-  `echo "#{ip + "\n" + @star}" >> stargazer.log` unless (@star = `curl -I #{ip} --anyauth --connect-timeout 0.1 --max-time 3`.to_s).empty?
+while true
+  ip = ([proc { Random.rand(0..255) }]*4).map(&:call).join('.')
+  print ip
+  star = `curl -I #{ip} --anyauth --connect-timeout 0.1 --max-time 3`.to_s
+  if star != ''
+    `echo "#{ip}" >> stargazer.log`
+    `curl -I #{ip} --anyauth --connect-timeout 0.1 --max-time 3 >> stargazer.log`
+  end
 end


### PR DESCRIPTION
Reverts dyspop/stargazer#2

Works fine in sublime build but returns an error in ruby 1.9.2
`stargazer.rb:3:in`rand': can't convert Range into Integer (TypeError)
    from stargazer.rb:3:in `block in <main>'
    from stargazer.rb:3:in`call'
    from stargazer.rb:3:in `map'
    from stargazer.rb:3:in`<main>'
`
